### PR TITLE
Use hashbrown in the validator

### DIFF
--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -11,6 +11,7 @@ pull-parser = { package = "sxd-pull-parser", path = "../pull-parser" }
 token = { package = "sxd-token", path = "../token" }
 string-slab = { package = "sxd-string-slab", path = "../string-slab" }
 
+hashbrown = { version = "0.11.0", default-features = false, features = ["ahash", "inline-more"] }
 once_cell = { version = "1.7.0", default-features = false, features = ["std"] }
 regex = { version = "1.4.3", default-features = false, features = ["std"] }
 snafu = "0.6.10"

--- a/validation/src/lib.rs
+++ b/validation/src/lib.rs
@@ -1,8 +1,9 @@
+use hashbrown::HashSet;
 use once_cell::sync::Lazy;
 use pull_parser::{Fuse, FusedIndexToken, FusedToken, Parser, XmlCharExt, XmlStrExt};
 use regex::Regex;
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
-use std::{collections::HashSet, io::Read};
+use std::io::Read;
 use string_slab::{CheckedArena, CheckedKey};
 use token::{Token, TokenKind};
 


### PR DESCRIPTION
Before:

```
  Time (mean ± σ):     775.6 ms ±   4.0 ms    [User: 758.6 ms, System: 17.0 ms]
  Range (min … max):   769.1 ms … 780.3 ms    10 runs
```

After:

```
  Time (mean ± σ):     773.8 ms ±   5.1 ms    [User: 753.9 ms, System: 20.0 ms]
  Range (min … max):   765.9 ms … 783.2 ms    10 runs
```

That's 99.77% of the previous time.

```
  Instructions:          6024457710 (-1.986409%)
  L1 Accesses:           8023149599 (-1.994044%)
  Estimated Cycles:      8380233309 (-1.924768%)
```